### PR TITLE
Fix: showing correct week day for the start of month (in month view)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -149,7 +149,7 @@ export default class HeatmapCalendar extends Plugin {
 				mappedEntries[this.getHowManyDaysIntoYear(new Date(e.date))] = newEntry
 			})
 
-			const firstDayOfYear = new Date(Date.UTC(year, 0, 1))
+			const firstDayOfYear = new Date(Date.UTC(year, (month !== 0) ? month-1 : 0, 1))
 			let numberOfEmptyDaysBeforeYearBegins = (firstDayOfYear.getUTCDay() + 6) % 7
 
 			interface Box {


### PR DESCRIPTION
Hi John!
I really like your fork as I can show/review a selected month only. Thank you!

The only issue, the beginning of month looked strange (boxes) - incorrect week days, then I found that it shows as it's January. I fixed it, you can see example in the picture attached. Please consider this PR. 

![Screenshot_2023-08-11_15-13-49](https://github.com/johnsbuck/heatmap-calendar-obsidian/assets/17794339/48304839-de6a-466c-8925-8a720ed30fe8)
